### PR TITLE
이승규/login 페이지 page.tsx에 임시 ui 코드 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,5 @@
+export const metadata = { title: "로그인" };
+
+export default function LoginPage() {
+  return <div>로그인 준비중</div>; // 임시 UI
+}


### PR DESCRIPTION
Vercel 빌드 중 Type error: File ... is not a module 오류 발생
<img width="850" height="255" alt="image" src="https://github.com/user-attachments/assets/7f2eee49-e5de-41b4-8491-fbe7dd841571" />

원인: src/app/(auth)/login/page.tsx 내 빈 페이지를 그대로 커밋하여 빌드 타임 오류 발생

문제 확인 후 page.tsx에 임시 코드 추가
로컬 터미널에서 npm run build 테스트 완료 후 정상 빌드 통과